### PR TITLE
Improve Docker build/documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,7 @@
 dist
 node_modules
 
-config/config.example.json
+config/config.json
 
 db.json
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ node_modules
 config/config.json
 
 db.json
+sounds
 
 CHANGELOG.md
 README.md

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@ sounds/*
 !sounds/.keep
 
 db.json
-
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ sounds/*
 !sounds/.keep
 
 db.json
+
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
 FROM node:carbon-alpine
 
-MAINTAINER Marko Kajzer <markokajzer91@gmail.com>
+LABEL maintainer="Marko Kajzer <markokajzer91@gmail.com>"
 
 # Install ffmpeg and other deps
 RUN apk add --no-cache --quiet build-base ffmpeg git make python
 
 WORKDIR /app
-COPY . /app
 COPY package*.json ./
 RUN npm install --quiet
+
+COPY . /app
 
 # Cleanup
 RUN apk del --quiet build-base
 
-CMD ["npm", "start"]
+# Build
+RUN npm run build
+
+CMD ["npm", "run", "serve"]

--- a/README.md
+++ b/README.md
@@ -62,13 +62,24 @@ For more configuration options see [here](../../wiki/Configuration).
 
 Need more details? You can find more detailed installation guides for [Unix](../../wiki/Unix) (including your Raspberry Pi), [macOS](../../wiki/macOS), and [Windows](../../wiki/Windows).
 
-#### Building via Docker
+#### Building/Running via Docker
 
-*Note*: Using this method, the bot will lose all sounds when restarting because the Docker container has its own file system.
-
-+ Simply clone the repo and run `docker build -t soundbot .` inside the folder.
-+ Afterwards start the bot via `docker run soundbot`.
-+ To run the container in the background use `docker run -d soundbot`.
++ First, clone the repo and run `docker build -t soundbot .` inside the folder.
++ Make a separate directory where your soundbot's data will live (Ex. `/etc/discord-soundbot`)
++ Then create a `docker-compose.yml` file in that directory with the following contents:
+```yaml
+version: '2'                                           
+services:                                              
+  discord-soundbot:                                    
+    image: soundbot
+    volumes:                                           
+    - ./sounds:/app/sounds                             
+    - ./config.json:/app/config/config.json            
+    - ./db.json:/app/db.json                           
+```
++ Create your `config.json` in the same directory
++ Afterwards start the bot via `docker-compose up`.
++ To run the container in the background use `docker-compose up -d`.
 
 
 ### Adding the bot to your server

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Need more details? You can find more detailed installation guides for [Unix](../
 
 #### Building/Running via Docker
 
-+ First, clone the repo and run `docker build -t soundbot .` inside the folder.
++ First, clone the repo and run `docker-compose build` inside the folder.
 + Make a separate directory where your soundbot's data will live (Ex. `/etc/discord-soundbot`)
 + Then create a `docker-compose.yml` file in that directory with the following contents:
 ```yaml
@@ -74,10 +74,11 @@ services:
     image: soundbot
     volumes:                                           
     - ./sounds:/app/sounds                             
-    - ./config.json:/app/config/config.json            
+    - ./config/config.json:/app/config/config.json
     - ./db.json:/app/db.json                           
 ```
-+ Create your `config.json` in the same directory
++ Create a `config/config.json` file as described above.
++ Create an empty `db.json` file.
 + Afterwards start the bot via `docker-compose up`.
 + To run the container in the background use `docker-compose up -d`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  discord-soundbot:
+    build: .
+    image: soundbot
+    volumes:
+    - ./sounds:/app/sounds
+    - ./config/config.json:/app/config/config.json
+    - ./db.json:/app/db.json


### PR DESCRIPTION
The current Dockerfile's entrypoint both builds AND runs the application, which is unnecessary.  Docker images are meant to be quick to start up, with all build steps completed as part of the image build.

Additional changes:
- Switch Dockerfile from deprecated `MAINTAINER` command to `LABEL`.
- Slightly better build caching by waiting until after `npm install` to copy the rest of the files.
- Update the documentation to include instructions for persisting data across containers.