### PR TITLE
Fixing !help message too long

### DIFF
--- a/config/locales/fr.json
+++ b/config/locales/fr.json
@@ -20,6 +20,11 @@
       "stop": "Arrêter le son et vider la file de lecture"
     },
 
+    "entrance": {
+      "set": "Joue le son spécifié lorsque vous entrez dans un salon",
+      "remove": "Supprime votre son d'entrée dans un salon"
+    },
+
     "tags": {
       "all": "Affiche la liste de tous les sons avec des tags",
       "add": "Ajouter un tag au son",

--- a/src/bot/commands/HelpCommand.ts
+++ b/src/bot/commands/HelpCommand.ts
@@ -16,52 +16,71 @@ export default class HelpCommand implements Command {
   }
 
   public run(message: Message) {
-    message.author.send(this.getFormattedListOfCommands());
+
+    this.getFormattedListOfCommands()
+        .forEach(element => {
+           message.author.send(element);
+        });
+
   }
 
   private getFormattedListOfCommands() {
     return [
-      '```',
-      this.localeService.t('help.headline', { prefix: this.config.prefix }),
-      '',
-      `welcome                          ${this.localeService.t('help.welcome')}`,
-      `commands                         ${this.localeService.t('help.commands')}`,
-      `help                             ${this.localeService.t('help.commands')}`,
+      [
+        this.localeService.t('help.headline', { prefix: this.config.prefix }),
+        '',
+        '```',
+        `welcome                          ${this.localeService.t('help.welcome')}`,
+        `commands                         ${this.localeService.t('help.commands')}`,
+        `help                             ${this.localeService.t('help.commands')}`,
+        '```',
 
-      `sounds                           ${this.localeService.t('help.sounds.all')}`,
-      `add                              ${this.localeService.t('help.sounds.add')}`,
-      `add <name> <link>                ${this.localeService.t('help.sounds.add')}`,
-      `add <name> <link> <start>        ${this.localeService.t('help.sounds.add')}`,
-      `add <name> <link> <start> <end>  ${this.localeService.t('help.sounds.add')}`,
-      `<sound>                          ${this.localeService.t('help.sounds.play')}`,
-      `combo <sound> ...                ${this.localeService.t('help.sounds.combo')}`,
-      `random                           ${this.localeService.t('help.sounds.random')}`,
-      `random <tag>                     ${this.localeService.t('help.sounds.random')}`,
-      `rename <old> <new>               ${this.localeService.t('help.sounds.rename')}`,
-      `remove <sound>                   ${this.localeService.t('help.sounds.remove')}`,
-      `download <sound>                 ${this.localeService.t('help.sounds.download')}`,
-      `stop                             ${this.localeService.t('help.sounds.stop')}`,
-      `leave                            ${this.localeService.t('help.sounds.stop')}`,
+        '```',
+        `sounds                           ${this.localeService.t('help.sounds.all')}`,
+        `add                              ${this.localeService.t('help.sounds.add')}`,
+        `add <name> <link>                ${this.localeService.t('help.sounds.add')}`,
+        `add <name> <link> <start>        ${this.localeService.t('help.sounds.add')}`,
+        `add <name> <link> <start> <end>  ${this.localeService.t('help.sounds.add')}`,
+        `<sound>                          ${this.localeService.t('help.sounds.play')}`,
+        `combo <sound> ...                ${this.localeService.t('help.sounds.combo')}`,
+        `random                           ${this.localeService.t('help.sounds.random')}`,
+        `random <tag>                     ${this.localeService.t('help.sounds.random')}`,
+        `rename <old> <new>               ${this.localeService.t('help.sounds.rename')}`,
+        `remove <sound>                   ${this.localeService.t('help.sounds.remove')}`,
+        `download <sound>                 ${this.localeService.t('help.sounds.download')}`,
+        `stop                             ${this.localeService.t('help.sounds.stop')}`,
+        `leave                            ${this.localeService.t('help.sounds.stop')}`,
+        '```',
 
-      `entrance <sound>                 ${this.localeService.t('help.entrance.set')}`,
-      `entrance                         ${this.localeService.t('help.entrance.remove')}`,
+        '```',
+        `entrance <sound>                 ${this.localeService.t('help.entrance.set')}`,
+        `entrance                         ${this.localeService.t('help.entrance.remove')}`,
+        '```',
+      ],
+      [
+        '```',
+        `tag <sound> <tag>                ${this.localeService.t('help.tags.add')}`,
+        `tag <sound>                      ${this.localeService.t('help.tags.list')}`,
+        `tag <sound> clear                ${this.localeService.t('help.tags.clear')}`,
+        `tags                             ${this.localeService.t('help.tags.all')}`,
+        `search <tag>                     ${this.localeService.t('help.tags.search')}`,
+        '```',
 
-      `tag <sound> <tag>                ${this.localeService.t('help.tags.add')}`,
-      `tag <sound>                      ${this.localeService.t('help.tags.list')}`,
-      `tag <sound> clear                ${this.localeService.t('help.tags.clear')}`,
-      `tags                             ${this.localeService.t('help.tags.all')}`,
-      `search <tag>                     ${this.localeService.t('help.tags.search')}`,
+        '```',
+        `mostplayed                       ${this.localeService.t('help.mostplayed')}`,
+        `lastadded                        ${this.localeService.t('help.lastadded')}`,
+        '```',
 
-      `mostplayed                       ${this.localeService.t('help.mostplayed')}`,
-      `lastadded                        ${this.localeService.t('help.lastadded')}`,
+        '```',
+        `ignore <user>                    ${this.localeService.t('help.ignore')}`,
+        `unignore <user>                  ${this.localeService.t('help.unignore')}`,
+        `avatar                           ${this.localeService.t('help.avatar')}`,
+        `avatar remove                    ${this.localeService.t('help.avatar')}`,
+        `config <option> <value>          ${this.localeService.t('help.config')}`,
+        `set <option> <value>             ${this.localeService.t('help.config')}`,
+        '```'
+      ]
+    ].map( (arr) => arr.join('\n'));
 
-      `ignore <user>                    ${this.localeService.t('help.ignore')}`,
-      `unignore <user>                  ${this.localeService.t('help.unignore')}`,
-      `avatar                           ${this.localeService.t('help.avatar')}`,
-      `avatar remove                    ${this.localeService.t('help.avatar')}`,
-      `config <option> <value>          ${this.localeService.t('help.config')}`,
-      `set <option> <value>             ${this.localeService.t('help.config')}`,
-      '```'
-    ].join('\n');
   }
 }

--- a/src/bot/commands/HelpCommand.ts
+++ b/src/bot/commands/HelpCommand.ts
@@ -18,10 +18,11 @@ export default class HelpCommand implements Command {
   }
 
   public run(message: Message, params: string[]) {
+    const page = parseInt(params[0]);
 
     [
       this.localeService.t('help.headline', { prefix: this.config.prefix }),
-      ...  this.chunker.chunkedMessages(this.getFormattedListOfCommands(), params)
+      ...  this.chunker.chunkedMessages(this.getFormattedListOfCommands(), page)
     ].forEach( (chunk: string) => message.author.send(chunk));
 
   }

--- a/src/bot/commands/HelpCommand.ts
+++ b/src/bot/commands/HelpCommand.ts
@@ -1,7 +1,7 @@
 import { Message } from 'discord.js';
 
 import Command from './base/Command';
-
+import MessageChunker from './helpers/MessageChunker';
 import Config from '@config/Config';
 import LocaleService from '@util/i18n/LocaleService';
 
@@ -9,33 +9,30 @@ export default class HelpCommand implements Command {
   public readonly TRIGGERS = ['commands', 'help'];
   private readonly config: Config;
   private readonly localeService: LocaleService;
+  private readonly chunker: MessageChunker;
 
-  constructor(config: Config, localeService: LocaleService) {
+  constructor(config: Config, localeService: LocaleService, chunker : MessageChunker) {
     this.config = config;
     this.localeService = localeService;
+    this.chunker = chunker;
   }
 
-  public run(message: Message) {
+  public run(message: Message, params: string[]) {
 
-    this.getFormattedListOfCommands()
-        .forEach(element => {
-           message.author.send(element);
-        });
+    [
+      this.localeService.t('help.headline', { prefix: this.config.prefix }),
+      ...  this.chunker.chunkedMessages(this.getFormattedListOfCommands(), params)
+    ].forEach( (chunk: string) => message.author.send(chunk));
 
   }
 
   private getFormattedListOfCommands() {
     return [
-      [
-        this.localeService.t('help.headline', { prefix: this.config.prefix }),
-        '',
-        '```',
+        // this.localeService.t('help.headline', { prefix: this.config.prefix }),
         `welcome                          ${this.localeService.t('help.welcome')}`,
         `commands                         ${this.localeService.t('help.commands')}`,
         `help                             ${this.localeService.t('help.commands')}`,
-        '```',
 
-        '```',
         `sounds                           ${this.localeService.t('help.sounds.all')}`,
         `add                              ${this.localeService.t('help.sounds.add')}`,
         `add <name> <link>                ${this.localeService.t('help.sounds.add')}`,
@@ -50,37 +47,27 @@ export default class HelpCommand implements Command {
         `download <sound>                 ${this.localeService.t('help.sounds.download')}`,
         `stop                             ${this.localeService.t('help.sounds.stop')}`,
         `leave                            ${this.localeService.t('help.sounds.stop')}`,
-        '```',
 
-        '```',
         `entrance <sound>                 ${this.localeService.t('help.entrance.set')}`,
         `entrance                         ${this.localeService.t('help.entrance.remove')}`,
-        '```',
-      ],
-      [
-        '```',
+
         `tag <sound> <tag>                ${this.localeService.t('help.tags.add')}`,
         `tag <sound>                      ${this.localeService.t('help.tags.list')}`,
         `tag <sound> clear                ${this.localeService.t('help.tags.clear')}`,
         `tags                             ${this.localeService.t('help.tags.all')}`,
         `search <tag>                     ${this.localeService.t('help.tags.search')}`,
-        '```',
 
-        '```',
         `mostplayed                       ${this.localeService.t('help.mostplayed')}`,
         `lastadded                        ${this.localeService.t('help.lastadded')}`,
-        '```',
 
-        '```',
         `ignore <user>                    ${this.localeService.t('help.ignore')}`,
         `unignore <user>                  ${this.localeService.t('help.unignore')}`,
         `avatar                           ${this.localeService.t('help.avatar')}`,
         `avatar remove                    ${this.localeService.t('help.avatar')}`,
         `config <option> <value>          ${this.localeService.t('help.config')}`,
         `set <option> <value>             ${this.localeService.t('help.config')}`,
-        '```'
-      ]
-    ].map( (arr) => arr.join('\n'));
+
+    ];
 
   }
 }

--- a/src/bot/commands/helpers/MessageChunker.ts
+++ b/src/bot/commands/helpers/MessageChunker.ts
@@ -10,7 +10,7 @@ export default class MessageChunker {
     this.localeService = localeService;
   }
 
-  public chunkedMessages(toChunk: string[], params: string[]): string[] {
+  public chunkedMessages(toChunk: string[], params: string[] = []): string[] {
     const chunks = this.chunkArray(toChunk);
 
     const indexInput = parseInt(params[0]);


### PR DESCRIPTION
For every language (except EN), the current !help command returns a message with length >2000 characters, which is the maximum length you can use to send a message.

I made a tiny fix to send 2 messages instead of one. Since the message had to be splitted, I made a small change to the formatting : each help "category" is now wrapped into its own blockquote.

Of course, I'm open to discussion if you feel like this fix should be done in a different way.

