### PR TITLE
Use Yarn in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ LABEL maintainer="Marko Kajzer <markokajzer91@gmail.com>"
 RUN apk add --no-cache --quiet build-base ffmpeg git make python
 
 WORKDIR /app
-COPY package*.json yarn.lock ./
-RUN yarn
+COPY package.json yarn.lock ./
+RUN yarn --silent
 
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ LABEL maintainer="Marko Kajzer <markokajzer91@gmail.com>"
 RUN apk add --no-cache --quiet build-base ffmpeg git make python
 
 WORKDIR /app
-COPY package*.json ./
-RUN npm install --quiet
+COPY package*.json yarn.lock ./
+RUN yarn
 
 COPY . /app
 
@@ -15,6 +15,6 @@ COPY . /app
 RUN apk del --quiet build-base
 
 # Build
-RUN npm run build
+RUN yarn build
 
-CMD ["npm", "run", "serve"]
+CMD ["yarn", "serve"]


### PR DESCRIPTION
There is a `yarn.lock` file in the repository, but the Dockerfile has been using `npm`, which could cause inconsistencies in package versions when running in Docker.