### PR TITLE
Set config from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Start the bot.
 const SoundBot = require('discord-soundbot');
 
 const myBot = new SoundBot({
-  clientID: 'YOUR_CLIENT_ID',
+  clientId: 'YOUR_CLIENT_ID',
   token: 'YOUR_BOT_USER_TOKEN'
 });
 myBot.start();

--- a/bin/soundbot.ts
+++ b/bin/soundbot.ts
@@ -12,4 +12,4 @@ localize.setLocale(config.language);
 const bot = container.cradle.soundBot as SoundBot;
 bot.start();
 
-console.info(localize.t('url', { clientId: config.clientID }));
+console.info(localize.t('url', { clientId: config.clientId }));

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,5 +1,5 @@
 {
-  "clientID": "YOUR_CLIENT_ID",
+  "clientId": "YOUR_CLIENT_ID",
   "token": "YOUR_BOT_USER_TOKEN",
 
   "language": "en",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "discord.js": "11.5.1",
     "fluent-ffmpeg": "2.1.2",
     "i18n": "0.8.4",
+    "lodash": "4.17.15",
     "lowdb": "1.0.0",
     "node-opus": "0.3.3",
     "replace-in-file": "4.2.0",

--- a/src/config/ConfigInterface.ts
+++ b/src/config/ConfigInterface.ts
@@ -1,7 +1,7 @@
 export default interface ConfigInterface {
   [key: string]: boolean | number | string | string[] | undefined;
 
-  clientID: string;
+  clientId: string;
   token: string;
   language?: string;
   prefix?: string;

--- a/src/config/DefaultConfig.ts
+++ b/src/config/DefaultConfig.ts
@@ -1,7 +1,7 @@
 import ConfigInterface from './ConfigInterface';
 
-const EXAMPLE_CONFIG: ConfigInterface = {
-  clientID: '',
+const DEFAULT_CONFIG: ConfigInterface = {
+  clientId: '',
   token: '',
 
   language: 'en',
@@ -15,4 +15,4 @@ const EXAMPLE_CONFIG: ConfigInterface = {
   game: ''
 };
 
-export default EXAMPLE_CONFIG;
+export default DEFAULT_CONFIG;

--- a/src/config/__jest__/Config.test.ts
+++ b/src/config/__jest__/Config.test.ts
@@ -1,0 +1,104 @@
+import Config from '../Config';
+
+jest.mock('fs');
+const randomString = (length: number) =>
+  Math.random()
+    .toString(36)
+    .substring(length);
+
+describe('Default config', () => {
+  const testedConfig = new Config();
+
+  test('Default clientID and token are empty', () => {
+    expect(testedConfig.clientId).toEqual('');
+    expect(testedConfig.token).toEqual('');
+  });
+
+  test('Default language is English', () => {
+    expect(testedConfig.language).toEqual('en');
+  });
+
+  test('Default command prefix is !', () => {
+    expect(testedConfig.prefix).toEqual('!');
+  });
+
+  test('Default whitelisted extensions are mp3 and wav files', () => {
+    expect(testedConfig.acceptedExtensions).toEqual(['.mp3', '.wav']);
+  });
+
+  test('Default maximum filesize is ', () => {
+    expect(testedConfig.maximumFileSize).toEqual(1000000);
+  });
+
+  test('Default setting to delete messages is false', () => {
+    expect(testedConfig.deleteMessages).toBe(false);
+  });
+
+  test('Default setting to stay in the channel is false', () => {
+    expect(testedConfig.stayInChannel).toBe(false);
+  });
+
+  test('Default setting to deafen the bot is false', () => {
+    expect(testedConfig.deafen).toBe(false);
+  });
+
+  test('Default game is not set', () => {
+    expect(testedConfig.game).toEqual('');
+  });
+});
+
+describe('Setting config from Environment Variables', () => {
+  const OLD_ENVIRONMENT_VARIABLES = process.env;
+
+  afterEach(() => {
+    process.env = OLD_ENVIRONMENT_VARIABLES;
+  });
+
+  test('You can overwrite any string value from the environment', () => {
+    process.env.CLIENT_ID = randomString(20);
+    process.env.TOKEN = randomString(20);
+    process.env.LANGUAGE = randomString(2);
+    process.env.PREFIX = randomString(1);
+    process.env.GAME = randomString(20);
+
+    const testedConfig = new Config();
+
+    expect(testedConfig.clientId).toEqual(process.env.CLIENT_ID);
+    expect(testedConfig.token).toEqual(process.env.TOKEN);
+    expect(testedConfig.language).toEqual(process.env.LANGUAGE);
+    expect(testedConfig.prefix).toEqual(process.env.PREFIX);
+    expect(testedConfig.game).toEqual(process.env.GAME);
+  });
+
+  test('You can set boolean config values to `true` from the environment', () => {
+    process.env.DELETE_MESSAGES = 'tRuE';
+    process.env.STAY_IN_CHANNEL = 'TruE';
+    process.env.DEAFEN = 'TRUE';
+
+    const testedConfig = new Config();
+
+    expect(testedConfig.deleteMessages).toBe(true);
+    expect(testedConfig.stayInChannel).toBe(true);
+    expect(testedConfig.deafen).toBe(true);
+  });
+
+  test('You can set boolean config values to `false` from the environment', () => {
+    process.env.DELETE_MESSAGES = 'false';
+    process.env.STAY_IN_CHANNEL = 'neen';
+    process.env.DEAFEN = 'anything else than true';
+
+    const testedConfig = new Config();
+
+    expect(testedConfig.deleteMessages).toBe(false);
+    expect(testedConfig.stayInChannel).toBe(false);
+    expect(testedConfig.deafen).toBe(false);
+  });
+
+  test('You can set array config values by using comma seperation', () => {
+    process.env.ACCEPTED_EXTENSIONS = '.mp3,.ogg,.wav,.mp4,.flac';
+
+    const testedConfig = new Config();
+
+    expect(testedConfig.acceptedExtensions).toEqual(['.mp3', '.ogg', '.wav', '.mp4', '.flac']);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ class DiscordSoundBot {
 
   public start() {
     this.bot.start();
-    console.info(localize.t('url', { clientId: this.config.clientID }));
+    console.info(localize.t('url', { clientId: this.config.clientId }));
   }
 
   private initializeWith(config: ConfigInterface, commands: Command[]) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,7 +2800,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@4, lodash@4.17.15, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
After writing some tests and some bug fixes I'd like to pitch the first extracted part of #60. 

### Why?
As a preparation for better docker pull & run support users should be able to set configs based upon environment variables. This assures that no rebuild & custom Docker image is needed when you just want to run the bot with Docker. 

### How?
We scrape the `process.env` and convert uppercase variables to Camel Case with Lodash. This maps back to our configKeys

### BC Breaks
Note that this required me to rename the `clientID` key to `clientId` as passing `CLIENT_ID`  in the environment variables made more sense than `CLIENT_I_D`



