### PR TITLE
360 no scope one click docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,21 +1,13 @@
-.git
-.gitignore
-.npmignore
-.node-version
+*
 
-dist
-node_modules
-vendor
+!bin
+!lib
+!config/locales
 
-config/config.json
-db.json
-sounds
+!sounds
 
-.eslintignore
-.eslintrc.yml
-docker-compose.yml
-Dockerfile
-jest.config.js
+!src
 
-CHANGELOG.md
-README.md
+!package.json
+!yarn.lock
+!tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 **Features**
 
 + Add possibility to set custom `timeout` when using `stayInChannel` via config option
++ Create one click Docker setup
 
 **Bugfixes**
 
 + Fix !avatar not sending the correct URL
++ Fixed docker setup
 
 ## 2.0.0 (2020-03-06)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,48 @@
-# Base will install runtime dependencies and configure generics
-FROM node:12.16
+# base stage will install runtime dependencies and configure generics
+FROM node:12.16-slim AS base
 
 LABEL maintainer="Marko Kajzer <markokajzer91@gmail.com>"
 WORKDIR /app
 
+# Install ffmpeg and other deps
+RUN apt-get update > /dev/null
+RUN apt-get install --yes -qq build-essential ffmpeg make python > /dev/null
+RUN rm -rf /var/lib/apt/lists
+
 # Copy some files
 COPY package.json yarn.lock ./
+
+# Install runtime dependencies
+RUN yarn install --production --frozen-lockfile --silent
+RUN yarn cache clean --force
+
+
+# build stage will compile ts to js
+FROM base AS build
+
+# Copy some files
 COPY . /app
 
-# Install ffmpeg and other deps
-RUN apt-get update
-RUN apt-get install --yes build-essential git ffmpeg make python > /dev/null
-RUN yarn install --silent
+# Install compile dependencies
+RUN yarn install --frozen-lockfile --silent
+RUN yarn cache clean --force --silent
 
-# Build
+# Build project
 RUN yarn build
 
 # Cleanup
-RUN apt-get remove --yes build-essential > /dev/null
+RUN apt-get remove --yes -qq build-essential make python > /dev/null
 
+
+# release stage has the bare minimum to run the application
+FROM base as release
+
+USER node
+ENV NODE_ENV=production
+
+COPY --chown=node:node --from=build ./app/dist ./dist
+COPY --chown=node:node --from=build ./app/config ./config
+COPY --chown=node:node --from=build ./app/sounds ./sounds
+
+# Start the bot
 CMD ["yarn", "serve"]

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ Need more details? You can find more detailed installation guides for [Unix](../
 
 #### Using npm
 
-Install the bot as a dependency using npm.
+You can also add the bot as a project dependency in your node project. Simply add it to your projects dependencies.
 
 ```
   $ npm install discord-soundbot
+  $ yarn add discord-soundbot
 ```
 
 Start the bot.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ To learn how to edit the config while the bot is running, see [below](#changing-
 
 ### Building
 
-The bot can be installed manually, via Docker, or as an npm package. When not using Docker the bot needs at least **Node.js v8.0.0** or newer and **FFmpeg** for its voice functionality.
+The bot can be installed manually, via Docker, or as an npm package. When not using Docker the bot needs at least **Node.js v12.0.0** or newer and **FFmpeg** for its voice functionality.
+
+#### Running via Docker
+
+This is the simplest solution if you just want to run the bot, and do not have any programming experience.
+
++ Make sure to have Docker installed.
++ Run `docker run -e CLIENT_ID={YOUR_CLIENT_ID} TOKEN={YOUR_TOKEN} discord-soundbot`
++ To run the bot in the background use the `-d` flag.
 
 #### Building manually
 
@@ -39,14 +47,6 @@ The bot can be installed manually, via Docker, or as an npm package. When not us
 + Run the bot with `yarn start`.
 
 Need more details? You can find more detailed installation guides for [Unix](../../wiki/Unix) (including your Raspberry Pi), [macOS](../../wiki/macOS), and [Windows](../../wiki/Windows).
-
-#### Building/Running via Docker
-
-+ Make sure to have Docker installed.
-+ Clone the repo and run `docker-compose build` inside the folder.
-+ If you do not already have one, create an empty `db.json` file.
-+ Afterwards start the bot via `docker-compose up`.
-+ To run the container in the background use `docker-compose up -d`.
 
 #### Using npm
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@discordjs/opus": "0.1.0",
-    "discord.js": "12.0.1",
+    "discord.js": "12.0.2",
     "fluent-ffmpeg": "2.1.2",
     "i18n": "0.8.4",
     "lodash": "4.17.15",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/i18n": "0.8.6",
     "@types/jest": "24.0.21",
     "@types/lowdb": "1.0.8",
-    "@types/node": "10.17.6",
+    "@types/node": "12.12.30",
     "@types/ws": "6.0.4",
     "@typescript-eslint/eslint-plugin": "2.6.1",
     "@typescript-eslint/parser": "2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,10 +427,10 @@
   version "10.7.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.7.1.tgz#b704d7c259aa40ee052eec678758a68d07132a2e"
 
-"@types/node@10.17.6":
-  version "10.17.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.6.tgz#1aaabd6f6470a6ac3824ab1e94d731ca1326d93d"
-  integrity sha512-0a2X6cgN3RdPBL2MIlR6Lt0KlM7fOFsutuXcdglcOq6WvLnYXgPQSh0Mx6tO1KCAE8MxbHSOSTWDoUxRq+l3DA==
+"@types/node@12.12.30":
+  version "12.12.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.30.tgz#3501e6f09b954de9c404671cefdbcc5d9d7c45f6"
+  integrity sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,10 +1169,10 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-discord.js@12.0.1:
-  version "12.0.1"
-  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-12.0.1.tgz#58574c0c9acc598095f943d6b14da4725d37b8b9"
-  integrity sha512-lUlrkAWSb5YTB1WpSZHjeUXxGlHK8VDjrlHLEP4lJj+etFAellURpmRYl29OPJ/7arQWB879pP4rvhhzpdOF7w==
+discord.js@12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-12.0.2.tgz#c4d68f1363d7fc05ed71a42dba6b930966ed8602"
+  integrity sha512-iZiEA4Y61gqq/EjFfLXnkRK9pLapnax/vTVDUhs/mAhyqozAy0GOlk/MZI9rSa1iIoKTWRq6P9CRKhLNT2wUnA==
   dependencies:
     "@discordjs/collection" "^0.1.5"
     abort-controller "^3.0.0"


### PR DESCRIPTION
## What has been done

+ Fixed `.dockerignore` file by making it a whitelist instead of blacklist
+ Split Docker setup into multiple stages

## How to test

+ Make sure that you can run the bot from Docker hub with the improved setup
  + `docker run -e CLIENT_ID=... TOKEN=... discord-soundbot`
+ Make sure that you can run the bot locally

## Notes

**Todos**

+ Add `tini` as entrypoint
  + Could also do as followup
+ Create an empty db.json file if not exists (necessary?)
+ Create a CI step to upload the newest docker image
  + Could also do as followup

**Questions**

+ Publish the new container
  + I actually forgot how to publish stuff on docker hub
  + How to publish the built & runnable container?
+ Do we still need docker-compose.yml?
+ Can we remove build-essential, make, python from artifacts (only needed for building)
  + This should decently reduce the size of the container
