### PR TITLE
360 no scope one click docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,21 +1,13 @@
-.git
-.gitignore
-.npmignore
-.node-version
+*
 
-dist
-node_modules
-vendor
+!bin
+!lib
+!config/locales
 
-config/config.json
-db.json
-sounds
+!sounds
 
-.eslintignore
-.eslintrc.yml
-docker-compose.yml
-Dockerfile
-jest.config.js
+!src
 
-CHANGELOG.md
-README.md
+!package.json
+!yarn.lock
+!tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 **Features**
 
 + Add possibility to set custom `timeout` when using `stayInChannel` via config option
++ Create one click Docker setup
 
 **Bugfixes**
 
 + Fix !avatar not sending the correct URL
++ Fixed docker setup
 
 ## 2.0.0 (2020-03-06)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,48 @@
-# Base will install runtime dependencies and configure generics
-FROM node:12.16
+# base stage will install runtime dependencies and configure generics
+FROM node:12.16-slim AS base
 
 LABEL maintainer="Marko Kajzer <markokajzer91@gmail.com>"
 WORKDIR /app
 
+# Install ffmpeg and other deps
+RUN apt-get update > /dev/null
+RUN apt-get install --yes -qq build-essential ffmpeg make python > /dev/null
+RUN rm -rf /var/lib/apt/lists
+
 # Copy some files
 COPY package.json yarn.lock ./
+
+# Install runtime dependencies
+RUN yarn install --production --frozen-lockfile --silent
+RUN yarn cache clean --force
+
+
+# build stage will compile ts to js
+FROM base AS build
+
+# Copy some files
 COPY . /app
 
-# Install ffmpeg and other deps
-RUN apt-get update
-RUN apt-get install --yes build-essential git ffmpeg make python > /dev/null
-RUN yarn install --silent
+# Install compile dependencies
+RUN yarn install --frozen-lockfile --silent
+RUN yarn cache clean --force --silent
 
-# Build
+# Build project
 RUN yarn build
 
 # Cleanup
-RUN apt-get remove --yes build-essential > /dev/null
+RUN apt-get remove --yes -qq build-essential make python > /dev/null
 
+
+# release stage has the bare minimum to run the application
+FROM base as release
+
+USER node
+ENV NODE_ENV=production
+
+COPY --chown=node:node --from=build ./app/dist ./dist
+COPY --chown=node:node --from=build ./app/config ./config
+COPY --chown=node:node --from=build ./app/sounds ./sounds
+
+# Start the bot
 CMD ["yarn", "serve"]

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ Need more details? You can find more detailed installation guides for [Unix](../
 
 #### Using npm
 
-Install the bot as a dependency using npm.
+You can also add the bot as a project dependency in your node project. Simply add it to your projects dependencies.
 
 ```
   $ npm install discord-soundbot
+  $ yarn add discord-soundbot
 ```
 
 Start the bot.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ To learn how to edit the config while the bot is running, see [below](#changing-
 
 ### Building
 
-The bot can be installed manually, via Docker, or as an npm package. When not using Docker the bot needs at least **Node.js v8.0.0** or newer and **FFmpeg** for its voice functionality.
+The bot can be installed manually, via Docker, or as an npm package. When not using Docker the bot needs at least **Node.js v12.0.0** or newer and **FFmpeg** for its voice functionality.
+
+#### Running via Docker
+
+This is the simplest solution if you just want to run the bot, and do not have any programming experience.
+
++ Make sure to have Docker installed.
++ Run `docker run -e CLIENT_ID={YOUR_CLIENT_ID} TOKEN={YOUR_TOKEN} discord-soundbot`
++ To run the bot in the background use the `-d` flag.
 
 #### Building manually
 
@@ -39,14 +47,6 @@ The bot can be installed manually, via Docker, or as an npm package. When not us
 + Run the bot with `yarn start`.
 
 Need more details? You can find more detailed installation guides for [Unix](../../wiki/Unix) (including your Raspberry Pi), [macOS](../../wiki/macOS), and [Windows](../../wiki/Windows).
-
-#### Building/Running via Docker
-
-+ Make sure to have Docker installed.
-+ Clone the repo and run `docker-compose build` inside the folder.
-+ If you do not already have one, create an empty `db.json` file.
-+ Afterwards start the bot via `docker-compose up`.
-+ To run the container in the background use `docker-compose up -d`.
 
 #### Using npm
 


### PR DESCRIPTION
## What has been done

+ Fixed `.dockerignore` file by making it a whitelist instead of blacklist
+ Split Docker setup into multiple stages

## How to test

+ Make sure that you can run the bot from Docker hub with the improved setup
  + `docker run -e CLIENT_ID=... TOKEN=... discord-soundbot`
+ Make sure that you can still run the bot locally

## Notes

**Todos**

+ Add `tini` as entrypoint
  + Could also do as followup
+ Create an empty db.json file if not exists (necessary?)
+ Create a CI step to upload the newest docker image
  + Could also do as followup

**Questions**

+ Publish the new container
  + How to publish the built & runnable container for different architectures?
+ How to actually run the bot? (update README accordingly)
+ Do we still need docker-compose.yml?
+ Can we remove build-essential, make, python from artifacts (only needed for building)
  + This should decently reduce the size of the container
