### PR TITLE
feat: allow admins to set entrance/exit sounds for other users

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Every user can set his own entrance sound, a sound that will play whenever the u
 
 The same is possible for exit sounds with `!exit <sound>` which will play the specified sound when leaving a voice channel.
 
+Administrators can set the entrance/exit sounds for other users.  Simply add their user id after the sound, e.g. `!entrance <sound> 1234567890`
+
 ### Tagging and searching sounds
 
 When your library of sounds gets too big and you forget what kinds of sounds you have, you can add tags to sounds.

--- a/src/bot/commands/EntranceCommand.ts
+++ b/src/bot/commands/EntranceCommand.ts
@@ -7,32 +7,34 @@ import Command from './base/Command';
 export default class EntranceCommand implements Command {
   public readonly TRIGGERS = ['entrance'];
   public readonly NUMBER_OF_PARAMETERS = 2;
-  public readonly USAGE = 'Usage: !entrance <sound> ?<user_id>';
+  public readonly USAGE = 'Usage: !entrance <sound> ?<userId>';
 
   public run(message: Message, params: string[]) {
+    let entranceSound;
+    let userId;
     if (params.length > this.NUMBER_OF_PARAMETERS) {
       message.channel.send(this.USAGE);
       return;
     }
 
     if (params.length === 1) {
-      var [entranceSound] = params;
-      var user_id = message.author.id;
+      [entranceSound] = params;
+      userId = message.author.id;
     } else {
       if (!message.member) return;
       if (!message.member.hasPermission(Permissions.FLAGS.ADMINISTRATOR!)) return;
 
-      var [entranceSound, user_id] = params;
+      [entranceSound, userId] = params;
     }
 
     if (!entranceSound) {
-      entrances.remove(user_id);
+      entrances.remove(userId);
       return;
     }
 
     const sounds = getSounds();
     if (!sounds.includes(entranceSound)) return;
 
-    entrances.add(user_id, entranceSound);
+    entrances.add(userId, entranceSound);
   }
 }

--- a/src/bot/commands/EntranceCommand.ts
+++ b/src/bot/commands/EntranceCommand.ts
@@ -1,4 +1,4 @@
-import { Message } from 'discord.js';
+import { Message, Permissions } from 'discord.js';
 
 import * as entrances from '@util/db/Entrances';
 import { getSounds } from '@util/SoundUtil';
@@ -6,17 +6,32 @@ import Command from './base/Command';
 
 export default class EntranceCommand implements Command {
   public readonly TRIGGERS = ['entrance'];
+  public readonly NUMBER_OF_PARAMETERS = 2;
+  public readonly USAGE = 'Usage: !entrance <sound> ?[user_id]';
 
   public run(message: Message, params: string[]) {
-    const [entranceSound] = params;
-    if (!entranceSound) {
-      entrances.remove(message.author.id);
+    if (params.length > this.NUMBER_OF_PARAMETERS) {
+      message.channel.send(this.USAGE);
+      return;
+    }
+
+    if (params.length === 1) {
+      var [entrance] = params;
+      var user_id = message.author.id;
+    }else{
+      if (!message.member) return;
+      
+      var [entrance, user_id] = params;
+    }
+
+    if (!entrance) {
+      entrances.remove(user_id);
       return;
     }
 
     const sounds = getSounds();
-    if (!sounds.includes(entranceSound)) return;
+    if (!sounds.includes(entrance)) return;
 
-    entrances.add(message.author.id, entranceSound);
+    entrances.add(user_id, entrance);
   }
 }

--- a/src/bot/commands/EntranceCommand.ts
+++ b/src/bot/commands/EntranceCommand.ts
@@ -7,7 +7,7 @@ import Command from './base/Command';
 export default class EntranceCommand implements Command {
   public readonly TRIGGERS = ['entrance'];
   public readonly NUMBER_OF_PARAMETERS = 2;
-  public readonly USAGE = 'Usage: !entrance <sound> ?[user_id]';
+  public readonly USAGE = 'Usage: !entrance <sound> ?<user_id>';
 
   public run(message: Message, params: string[]) {
     if (params.length > this.NUMBER_OF_PARAMETERS) {
@@ -16,22 +16,23 @@ export default class EntranceCommand implements Command {
     }
 
     if (params.length === 1) {
-      var [entrance] = params;
+      var [entranceSound] = params;
       var user_id = message.author.id;
     }else{
       if (!message.member) return;
+      if (!message.member.hasPermission(Permissions.FLAGS.ADMINISTRATOR!)) return;
       
-      var [entrance, user_id] = params;
+      var [entranceSound, user_id] = params;
     }
 
-    if (!entrance) {
+    if (!entranceSound) {
       entrances.remove(user_id);
       return;
     }
 
     const sounds = getSounds();
-    if (!sounds.includes(entrance)) return;
+    if (!sounds.includes(entranceSound)) return;
 
-    entrances.add(user_id, entrance);
+    entrances.add(user_id, entranceSound);
   }
 }

--- a/src/bot/commands/EntranceCommand.ts
+++ b/src/bot/commands/EntranceCommand.ts
@@ -18,10 +18,10 @@ export default class EntranceCommand implements Command {
     if (params.length === 1) {
       var [entranceSound] = params;
       var user_id = message.author.id;
-    }else{
+    } else {
       if (!message.member) return;
       if (!message.member.hasPermission(Permissions.FLAGS.ADMINISTRATOR!)) return;
-      
+
       var [entranceSound, user_id] = params;
     }
 

--- a/src/bot/commands/ExitCommand.ts
+++ b/src/bot/commands/ExitCommand.ts
@@ -1,4 +1,4 @@
-import { Message } from 'discord.js';
+import { Message, Permissions } from 'discord.js';
 
 import * as exits from '@util/db/Exits';
 import { getSounds } from '@util/SoundUtil';
@@ -6,17 +6,33 @@ import Command from './base/Command';
 
 export default class ExitCommand implements Command {
   public readonly TRIGGERS = ['exit'];
+  public readonly NUMBER_OF_PARAMETERS = 2;
+  public readonly USAGE = 'Usage: !exit <sound> ?<user_id>';
 
   public run(message: Message, params: string[]) {
-    const [exitSound] = params;
+    if (params.length > this.NUMBER_OF_PARAMETERS) {
+      message.channel.send(this.USAGE);
+      return;
+    }
+
+    if (params.length === 1) {
+      var [exitSound] = params;
+      var user_id = message.author.id;
+    }else{
+      if (!message.member) return;
+      if (!message.member.hasPermission(Permissions.FLAGS.ADMINISTRATOR!)) return;
+      
+      var [exitSound, user_id] = params;
+    }
+
     if (!exitSound) {
-      exits.remove(message.author.id);
+      exits.remove(user_id);
       return;
     }
 
     const sounds = getSounds();
     if (!sounds.includes(exitSound)) return;
 
-    exits.add(message.author.id, exitSound);
+    exits.add(user_id, exitSound);
   }
 }

--- a/src/bot/commands/ExitCommand.ts
+++ b/src/bot/commands/ExitCommand.ts
@@ -11,7 +11,7 @@ export default class ExitCommand implements Command {
 
   public run(message: Message, params: string[]) {
     let exitSound;
-    let userId
+    let userId;
     if (params.length > this.NUMBER_OF_PARAMETERS) {
       message.channel.send(this.USAGE);
       return;

--- a/src/bot/commands/ExitCommand.ts
+++ b/src/bot/commands/ExitCommand.ts
@@ -7,32 +7,34 @@ import Command from './base/Command';
 export default class ExitCommand implements Command {
   public readonly TRIGGERS = ['exit'];
   public readonly NUMBER_OF_PARAMETERS = 2;
-  public readonly USAGE = 'Usage: !exit <sound> ?<user_id>';
+  public readonly USAGE = 'Usage: !exit <sound> ?<userId>';
 
   public run(message: Message, params: string[]) {
+    let exitSound;
+    let userId
     if (params.length > this.NUMBER_OF_PARAMETERS) {
       message.channel.send(this.USAGE);
       return;
     }
 
     if (params.length === 1) {
-      var [exitSound] = params;
-      var user_id = message.author.id;
+      [exitSound] = params;
+      userId = message.author.id;
     } else {
       if (!message.member) return;
       if (!message.member.hasPermission(Permissions.FLAGS.ADMINISTRATOR!)) return;
 
-      var [exitSound, user_id] = params;
+      [exitSound, userId] = params;
     }
 
     if (!exitSound) {
-      exits.remove(user_id);
+      exits.remove(userId);
       return;
     }
 
     const sounds = getSounds();
     if (!sounds.includes(exitSound)) return;
 
-    exits.add(user_id, exitSound);
+    exits.add(userId, exitSound);
   }
 }

--- a/src/bot/commands/ExitCommand.ts
+++ b/src/bot/commands/ExitCommand.ts
@@ -18,10 +18,10 @@ export default class ExitCommand implements Command {
     if (params.length === 1) {
       var [exitSound] = params;
       var user_id = message.author.id;
-    }else{
+    } else {
       if (!message.member) return;
       if (!message.member.hasPermission(Permissions.FLAGS.ADMINISTRATOR!)) return;
-      
+
       var [exitSound, user_id] = params;
     }
 

--- a/src/bot/commands/HelpCommand.ts
+++ b/src/bot/commands/HelpCommand.ts
@@ -47,7 +47,7 @@ export default class HelpCommand implements Command {
       `stop                                   ${localize.t('help.sounds.stop')}`,
       `leave                                  ${localize.t('help.sounds.stop')}`,
 
-      `entrance <sound> ?[user_id]            ${localize.t('help.entrance.set')}`,
+      `entrance <sound> ?<user_id>            ${localize.t('help.entrance.set')}`,
       `entrance                               ${localize.t('help.entrance.remove')}`,
       `exit <sound>                           ${localize.t('help.exit.set')}`,
       `exit                                   ${localize.t('help.exit.remove')}`,

--- a/src/bot/commands/HelpCommand.ts
+++ b/src/bot/commands/HelpCommand.ts
@@ -47,7 +47,7 @@ export default class HelpCommand implements Command {
       `stop                                   ${localize.t('help.sounds.stop')}`,
       `leave                                  ${localize.t('help.sounds.stop')}`,
 
-      `entrance <sound>                       ${localize.t('help.entrance.set')}`,
+      `entrance <sound> ?[user_id]            ${localize.t('help.entrance.set')}`,
       `entrance                               ${localize.t('help.entrance.remove')}`,
       `exit <sound>                           ${localize.t('help.exit.set')}`,
       `exit                                   ${localize.t('help.exit.remove')}`,

--- a/src/bot/commands/RemoveCommand.ts
+++ b/src/bot/commands/RemoveCommand.ts
@@ -14,6 +14,7 @@ export default class RemoveCommand implements Command {
 
   public run(message: Message, params: string[]) {
     if (!message.member) return;
+    if (!message.member.hasPermission(Permissions.FLAGS.ADMINISTRATOR!)) return;
 
     if (params.length !== this.NUMBER_OF_PARAMETERS) {
       message.channel.send(this.USAGE);

--- a/src/bot/commands/RemoveCommand.ts
+++ b/src/bot/commands/RemoveCommand.ts
@@ -14,7 +14,6 @@ export default class RemoveCommand implements Command {
 
   public run(message: Message, params: string[]) {
     if (!message.member) return;
-    if (!message.member.hasPermission(Permissions.FLAGS.ADMINISTRATOR!)) return;
 
     if (params.length !== this.NUMBER_OF_PARAMETERS) {
       message.channel.send(this.USAGE);


### PR DESCRIPTION
This will allow admin users to set the entrance/exit sounds for other users.  Useful for larger servers where not all admins have access to the DB, but want to be able to remove/update users' sounds either due to them being offensive, or to mess with said user :)

It does not impact current user flow as the default no params/one param will still work for the current user.  Only with the addition of a user ID will the new functionality be called