### PR TITLE
More user status messages and better error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ sounds/*
 
 db.json
 test-db.json
+
+.idea

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -47,6 +47,10 @@
             "notFound": "{sound} not found!"
         }
     },
+    "status": {
+        "received" : "⏳ running {command}",
+        "completed" : "{command} completed"
+    },
     "errors": {
         "format": {
             "sound": "💥📛 Filename has to be all letters and numbers!",
@@ -55,7 +59,8 @@
         },
         "permissions": "I need permissions to join the channel.",
         "sounds": {
-            "exists": "{sound} already exists!"
+            "exists": "{sound} already exists!",
+            "notFound": "{sound} not found"
         },
         "unauthorized": "You need to be an admin or have an elevated role to perform this command",
         "unspecific": "💥 Something went wrong! Please try again, or let the bot creator know what happened."

--- a/config/locales/it.json
+++ b/config/locales/it.json
@@ -19,7 +19,14 @@
             "remove": "Non sto piu' ignorando {user}!"
         },
         "lang": {
-            "title": "Lingue disponibili   💬"
+            "success": "Impostata lingua in: `{language}`!  {flag}",
+            "title": "Lingue disponibili   💬",
+            "usage": "Scrivi **{command} <lingua>** per scegliere!\nEsempio: **{command} Italian** oppure **{command} nl**"
+        },
+        "modify": {
+            "error": "Qualcosa é andato storto modificando `{modifier}` per {sound}!",
+            "notFound": "Modificatore non trovato: `{modifier}`!",
+            "success": "Impostato modificatore: `{modifier}` per {sound}!"
         },
         "remove": {
             "notFound": "{sound} non trovato!",
@@ -40,14 +47,23 @@
             "notFound": "{sound} non trovato!"
         }
     },
+    "status": {
+        "received" : "⏳ eseguendo {command}",
+        "completed" : "{command} completato"
+    },
     "errors": {
         "format": {
-            "url": "💥🚋 L'URL non e' valido!"
+            "sound": "💥📛 Il nome del file deve contenere solo lettere e numeri!",
+            "time": "💥⌚ Il tempo specificato non é nel formato [[hh:]mm:]ss[.xxx].",
+            "url": "💥🚋 L'URL non é valido!"
         },
+        "permissions": "I need permissions to join the channel.",
         "sounds": {
-            "exists": "{sound} esiste gia'!"
+            "exists": "{sound} esiste giá!",
+            "notFound": "{sound} non trovato."
         },
-        "unspecific": "💥 Qualcosa e' andato storto!"
+        "unauthorized": "Devi essere un admin o avere un ruolo privilegiato per eseguire questo comando",
+        "unspecific": "💥 Qualcosa é andato storto!"
     },
     "help": {
         "avatar": "Mostra, cambia o rimuove l'avatar corrente",

--- a/src/bot/MessageHandler.ts
+++ b/src/bot/MessageHandler.ts
@@ -16,16 +16,16 @@ export default class MessageHandler {
     this.commands = commands;
   }
 
-  public handle(message: Message) {
-    if (!this.isValidMessage(message)) return;
+  public async handle(message: Message) {
+    if (!MessageHandler.isValidMessage(message)) return;
 
     const messageToHandle = message;
     messageToHandle.content = message.content.substring(config.prefix.length);
 
-    this.execute(messageToHandle);
+    await this.execute(messageToHandle);
   }
 
-  private isValidMessage(message: Message) {
+  private static isValidMessage(message: Message) {
     return (
       !message.author.bot &&
       !message.isDirectMessage() &&
@@ -34,15 +34,33 @@ export default class MessageHandler {
     );
   }
 
-  private execute(message: Message) {
+  private async execute(message: Message) {
     const [command, ...params] = message.content.split(' ');
     const commandToRun = this.commands.get(command);
 
     if (commandToRun.elevated && !userHasElevatedRole(message.member)) {
-      message.channel.send(localize.t('errors.unauthorized'));
+      await message.channel.send(localize.t('errors.unauthorized'));
       return;
     }
 
-    commandToRun.run(message, params);
+    const statusMsg = await message.reply(localize.t('status.received', { command }));
+    statusMsg.reference = {
+      // This should really be done by the discordjs library since we are replying
+      channelID: message.channel.id,
+      guildID: message.guild?.id || '',
+      messageID: message.id
+    };
+
+    try {
+      await commandToRun.run(statusMsg, params);
+
+      if (statusMsg.editedAt === null) {
+        // If we haven't reported any status
+        await statusMsg.edit(localize.t('status.completed', { command }));
+      }
+    } catch (e) {
+      console.error(e);
+      await statusMsg.edit(localize.t('errors.unspecific'));
+    }
   }
 }

--- a/src/bot/__test__/MessageHandler.test.ts
+++ b/src/bot/__test__/MessageHandler.test.ts
@@ -53,15 +53,19 @@ describe('MessageHandler', () => {
 
     // @ts-ignore
     jest.spyOn(messageHandler, 'execute');
+    // eslint-disable-next-line no-unused-vars
+    jest.spyOn(message, 'reply').mockImplementation(async (content, options) => message);
+    // eslint-disable-next-line no-unused-vars
+    jest.spyOn(message, 'edit').mockImplementation(async (content, options) => message);
     jest.spyOn(ignoreList, 'exists').mockImplementation(() => false);
   });
 
   describe('handle', () => {
-    it('does nothing when message is from bot', () => {
+    it('does nothing when message is from bot', async () => {
       Object.defineProperty(message.author, 'bot', { value: true });
       jest.spyOn(message, 'isDirectMessage');
 
-      messageHandler.handle(message);
+      await messageHandler.handle(message);
 
       expect(message.author.bot).toBe(true);
       expect(message.isDirectMessage).not.toHaveBeenCalled();
@@ -70,11 +74,11 @@ describe('MessageHandler', () => {
       expect(messageHandler.execute).not.toHaveBeenCalled();
     });
 
-    it('does nothing when message is DM', () => {
+    it('does nothing when message is DM', async () => {
       Object.defineProperty(message.channel, 'type', { value: 'dm' });
       jest.spyOn(message, 'hasPrefix');
 
-      messageHandler.handle(message);
+      await messageHandler.handle(message);
 
       expect(message.isDirectMessage()).toBe(true);
       expect(message.hasPrefix).not.toHaveBeenCalled();
@@ -83,9 +87,9 @@ describe('MessageHandler', () => {
       expect(messageHandler.execute).not.toHaveBeenCalled();
     });
 
-    it('does nothing when message does not have prefix', () => {
+    it('does nothing when message does not have prefix', async () => {
       Object.defineProperty(message, 'content', { value: 'NOT_PREFIX' });
-      messageHandler.handle(message);
+      await messageHandler.handle(message);
 
       expect(message.hasPrefix(DEFAULT_CONFIG.prefix!)).toBe(false);
       expect(ignoreList.exists).not.toHaveBeenCalled();
@@ -94,44 +98,44 @@ describe('MessageHandler', () => {
       expect(messageHandler.execute).not.toHaveBeenCalled();
     });
 
-    it('does nothing when user is ignored', () => {
+    it('does nothing when user is ignored', async () => {
       jest.spyOn(ignoreList, 'exists').mockImplementation(() => true);
-      messageHandler.handle(message);
+      await messageHandler.handle(message);
 
       // @ts-ignore
       expect(messageHandler.execute).not.toHaveBeenCalled();
     });
 
-    it('executes a given command when the command is valid', () => {
+    it('executes a given command when the command is valid', async () => {
       Object.defineProperty(message, 'content', { value: '!help' });
       jest.spyOn(helpCommand, 'run');
 
       commands.registerCommands([helpCommand]);
-      messageHandler.handle(message);
+      await messageHandler.handle(message);
 
       // @ts-ignore
       expect(messageHandler.execute).toHaveBeenCalledWith(message);
       expect(helpCommand.run).toHaveBeenCalledWith(message, []);
     });
 
-    it('executes sound command if no command was found', () => {
+    it('executes sound command if no command was found', async () => {
       Object.defineProperty(message, 'content', { value: '!airhorn' });
       jest.spyOn(soundCommand, 'run');
 
       commands.registerCommands([helpCommand]);
-      messageHandler.handle(message);
+      await messageHandler.handle(message);
 
       // @ts-ignore
       expect(messageHandler.execute).toHaveBeenCalledWith(message);
       expect(soundCommand.run).toHaveBeenCalledWith(message, []);
     });
 
-    it('does not execute an elevated command if user does not have elevated role', () => {
+    it('does not execute an elevated command if user does not have elevated role', async () => {
       Object.defineProperty(message, 'content', { value: '!avatar' });
       jest.spyOn(avatarCommand, 'run');
 
       commands.registerCommands([avatarCommand]);
-      messageHandler.handle(message);
+      await messageHandler.handle(message);
 
       // @ts-ignore
       expect(messageHandler.execute).toHaveBeenCalledWith(message);

--- a/src/bot/__test__/MessageHandler.test.ts
+++ b/src/bot/__test__/MessageHandler.test.ts
@@ -53,10 +53,8 @@ describe('MessageHandler', () => {
 
     // @ts-ignore
     jest.spyOn(messageHandler, 'execute');
-    // eslint-disable-next-line no-unused-vars
-    jest.spyOn(message, 'reply').mockImplementation(async (content, options) => message);
-    // eslint-disable-next-line no-unused-vars
-    jest.spyOn(message, 'edit').mockImplementation(async (content, options) => message);
+    jest.spyOn(message, 'reply').mockImplementation(async () => message);
+    jest.spyOn(message, 'edit').mockImplementation(async () => message);
     jest.spyOn(ignoreList, 'exists').mockImplementation(() => false);
   });
 

--- a/src/commands/base/Command.ts
+++ b/src/commands/base/Command.ts
@@ -6,5 +6,5 @@ export default abstract class Command {
   readonly usage?: string;
   readonly elevated: boolean = false;
 
-  abstract run(message: Message, params?: string[]): void;
+  abstract run(message: Message, params?: string[]): Promise<any>;
 }

--- a/src/commands/config/AvatarCommand.ts
+++ b/src/commands/config/AvatarCommand.ts
@@ -17,9 +17,9 @@ export class AvatarCommand extends ConfigCommand implements UserCommand {
     this.user = user;
   }
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     if (params.length === this.numberOfParameters && params[0] === 'remove') {
-      this.user.setAvatar('');
+      await this.user.setAvatar('');
       return;
     }
 
@@ -29,24 +29,24 @@ export class AvatarCommand extends ConfigCommand implements UserCommand {
     }
 
     if (message.attachments.size !== 1) {
-      message.channel.send(this.usage);
+      await message.edit(this.usage);
       return;
     }
 
-    this.user
+    await this.user
       .setAvatar(message.attachments.first()!.url)
-      .catch(() => message.channel.send(localize.t('commands.avatar.errors.tooFast')));
+      .catch(() => message.edit(localize.t('commands.avatar.errors.tooFast')));
   }
 
-  private listAvatar(message: Message) {
+  private async listAvatar(message: Message) {
     if (!this.user.avatarURL()) {
-      message.channel.send(
+      await message.edit(
         localize.t('commands.avatar.errors.noAvatar', { prefix: this.config.prefix })
       );
       return;
     }
 
-    message.channel.send(
+    await message.edit(
       localize.t('commands.avatar.url', {
         url: this.user.displayAvatarURL({ dynamic: true, format: 'png', size: 256 })
       })

--- a/src/commands/config/ConfigCommand.ts
+++ b/src/commands/config/ConfigCommand.ts
@@ -17,23 +17,23 @@ export class ConfigCommand extends BaseConfigCommand implements UserCommand {
     this.user = user;
   }
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     if (params.length < this.numberOfParameters) {
-      message.channel.send(this.usage);
+      await message.edit(this.usage);
       return;
     }
 
     const [field, ...value] = params;
 
     if (!this.config.has(field)) {
-      message.channel.send(localize.t('commands.config.notFound', { field }));
+      await message.edit(localize.t('commands.config.notFound', { field }));
       return;
     }
 
     const configValue = this.config.set(field, value)!;
     this.postProcess(field);
 
-    message.channel.send(
+    await message.edit(
       localize.t('commands.config.success', { field, value: configValue.toString() })
     );
   }

--- a/src/commands/config/IgnoreCommand.ts
+++ b/src/commands/config/IgnoreCommand.ts
@@ -10,17 +10,17 @@ export class IgnoreCommand extends Command {
   public readonly usage = 'Usage: !ignore <user>';
   public readonly elevated = true;
 
-  public run(message: Message) {
+  public async run(message: Message) {
     const { users } = message.mentions;
     if (users.size < 1) {
-      message.channel.send(this.usage);
-      message.channel.send(localize.t('helpers.userFinder.error'));
+      await message.edit(this.usage);
+      await message.channel.send(localize.t('helpers.userFinder.error'));
       return;
     }
 
-    users.forEach(user => {
+    await users.forEach(user => {
       ignoreList.add(user.id);
-      message.channel.send(localize.t('commands.ignore.add', { user: user.username }));
+      message.edit(localize.t('commands.ignore.add', { user: user.username }));
     });
   }
 }

--- a/src/commands/config/LanguageCommand.ts
+++ b/src/commands/config/LanguageCommand.ts
@@ -18,21 +18,21 @@ const FLAGS: Dictionary<string> = {
 export class LanguageCommand extends ConfigCommand {
   public readonly triggers = ['lang'];
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     const [chosenLanguage] = params;
     const language =
       chosenLanguage &&
       this.getLanguageMap().findKey((value, key) => [key, value].includes(chosenLanguage));
 
     if (!language) {
-      message.channel.send(this.help());
+      await message.edit(this.help());
       return;
     }
 
     this.config.set('language', [language]);
     localize.setLocale(language);
 
-    message.channel.send(
+    await message.edit(
       localize.t('commands.lang.success', { flag: FLAGS[language], language: chosenLanguage })
     );
   }

--- a/src/commands/config/UnignoreCommand.ts
+++ b/src/commands/config/UnignoreCommand.ts
@@ -10,17 +10,17 @@ export class UnignoreCommand extends Command {
   public readonly usage = 'Usage: !unignore <user>';
   public readonly elevated = true;
 
-  public run(message: Message) {
+  public async run(message: Message) {
     const { users } = message.mentions;
     if (users.size < 1) {
-      message.channel.send(this.usage);
-      message.channel.send(localize.t('helpers.userFinder.error'));
+      await message.edit(this.usage);
+      await message.channel.send(localize.t('helpers.userFinder.error'));
       return;
     }
 
-    users.forEach(user => {
+    await users.forEach(user => {
       ignoreList.remove(user.id);
-      message.channel.send(localize.t('commands.ignore.remove', { user: user.username }));
+      message.edit(localize.t('commands.ignore.remove', { user: user.username }));
     });
   }
 }

--- a/src/commands/config/__mocks__/AvatarCommand.ts
+++ b/src/commands/config/__mocks__/AvatarCommand.ts
@@ -9,7 +9,7 @@ export class AvatarCommand extends Command implements UserCommand {
     // noop
   }
 
-  public run() {
+  public async run() {
     // noop
   }
 }

--- a/src/commands/help/HelpCommand.ts
+++ b/src/commands/help/HelpCommand.ts
@@ -8,11 +8,12 @@ import chunkedMessages from '../util/chunkedMessages';
 export class HelpCommand extends ConfigCommand {
   public readonly triggers = ['commands', 'help'];
 
-  public run(message: Message) {
+  public async run(message: Message) {
     const helpMessage = this.getFormattedListOfCommands();
     const chunkedHelpMessage = chunkedMessages(helpMessage);
 
-    chunkedHelpMessage.forEach(chunk => message.author.send(chunk));
+    const author = await message.referencedAuthor();
+    chunkedHelpMessage.forEach(chunk => author.send(chunk));
   }
 
   private getFormattedListOfCommands() {

--- a/src/commands/help/LastAddedCommand.ts
+++ b/src/commands/help/LastAddedCommand.ts
@@ -9,8 +9,8 @@ export class LastAddedCommand extends Command {
   public readonly triggers = ['lastadded'];
   private readonly amount = 5;
 
-  public run(message: Message) {
-    message.channel.send(['```', ...this.getLastAddedSounds(), '```'].join('\n'));
+  public async run(message: Message) {
+    await message.edit(['```', ...this.getLastAddedSounds(), '```'].join('\n'));
   }
 
   private getLastAddedSounds() {

--- a/src/commands/help/MostPlayedCommand.ts
+++ b/src/commands/help/MostPlayedCommand.ts
@@ -8,11 +8,11 @@ import Command from '../base/Command';
 export class MostPlayedCommand extends Command {
   public readonly triggers = ['mostplayed'];
 
-  public run(message: Message) {
+  public async run(message: Message) {
     const formattedMessage = this.getFormattedMessage();
     if (!formattedMessage) return;
 
-    message.channel.send(formattedMessage);
+    await message.edit(formattedMessage);
   }
 
   private getFormattedMessage() {

--- a/src/commands/help/PingCommand.ts
+++ b/src/commands/help/PingCommand.ts
@@ -5,7 +5,7 @@ import Command from '../base/Command';
 export class PingCommand extends Command {
   public readonly triggers = ['ping'];
 
-  public run(message: Message) {
-    message.channel.send('Pong!');
+  public async run(message: Message) {
+    await message.edit('Pong!');
   }
 }

--- a/src/commands/help/WelcomeCommand.ts
+++ b/src/commands/help/WelcomeCommand.ts
@@ -7,7 +7,7 @@ import ConfigCommand from '../base/ConfigCommand';
 export class WelcomeCommand extends ConfigCommand {
   public readonly triggers = ['welcome'];
 
-  public run(message: Message) {
-    message.channel.send(localize.t('welcome', { prefix: this.config.prefix }));
+  public async run(message: Message) {
+    await message.edit(localize.t('welcome', { prefix: this.config.prefix }));
   }
 }

--- a/src/commands/help/__mocks__/HelpCommand.ts
+++ b/src/commands/help/__mocks__/HelpCommand.ts
@@ -3,7 +3,7 @@ import Command from '../../base/Command';
 export class HelpCommand extends Command {
   public readonly triggers = ['commands', 'help'];
 
-  public run() {
+  public async run() {
     // noop
   }
 }

--- a/src/commands/manage/AddCommand.ts
+++ b/src/commands/manage/AddCommand.ts
@@ -15,12 +15,14 @@ export class AddCommand extends Command {
     this.youtubeDownloader = youtubeDownloader;
   }
 
-  public run(message: Message, params: string[]) {
-    if (!message.attachments.size) {
-      this.youtubeDownloader.handle(message, params);
+  public async run(message: Message, params: string[]) {
+    const originalMsg = await message.referencedMessage();
+
+    if (!originalMsg.attachments.size) {
+      await this.youtubeDownloader.handle(message, params);
       return;
     }
 
-    this.attachmentDownloader.handle(message);
+    await this.attachmentDownloader.handle(message);
   }
 }

--- a/src/commands/manage/DownloadCommand.ts
+++ b/src/commands/manage/DownloadCommand.ts
@@ -9,9 +9,9 @@ export class DownloadCommand extends Command {
   public readonly numberOfParameters = 1;
   public readonly usage = 'Usage: !download <sound>';
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     if (params.length !== this.numberOfParameters) {
-      message.channel.send(this.usage);
+      await message.edit(this.usage);
       return;
     }
 
@@ -19,6 +19,6 @@ export class DownloadCommand extends Command {
     if (!existsSound(sound)) return;
 
     const attachment = new MessageAttachment(getPathForSound(sound));
-    message.channel.send(attachment);
+    await message.channel.send(attachment);
   }
 }

--- a/src/commands/manage/EntranceCommand.ts
+++ b/src/commands/manage/EntranceCommand.ts
@@ -2,22 +2,28 @@ import { Message } from 'discord.js';
 
 import * as entrances from '~/util/db/Entrances';
 import { getSounds } from '~/util/SoundUtil';
+import localize from '~/util/i18n/localize';
 
 import Command from '../base/Command';
 
 export class EntranceCommand extends Command {
   public readonly triggers = ['entrance'];
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     const [entranceSound] = params;
+    const { id: authorId } = await message.referencedAuthor();
+
     if (!entranceSound) {
-      entrances.remove(message.author.id);
+      entrances.remove(authorId);
       return;
     }
 
     const sounds = getSounds();
-    if (!sounds.includes(entranceSound)) return;
+    if (!sounds.includes(entranceSound)) {
+      await message.edit(localize.t('errors.sounds.notFound', { sound: entranceSound }));
+      return;
+    }
 
-    entrances.add(message.author.id, entranceSound);
+    entrances.add(authorId, entranceSound);
   }
 }

--- a/src/commands/manage/EntranceCommand.ts
+++ b/src/commands/manage/EntranceCommand.ts
@@ -1,8 +1,8 @@
 import { Message } from 'discord.js';
 
 import * as entrances from '~/util/db/Entrances';
-import { getSounds } from '~/util/SoundUtil';
 import localize from '~/util/i18n/localize';
+import { getSounds } from '~/util/SoundUtil';
 
 import Command from '../base/Command';
 

--- a/src/commands/manage/ExitCommand.ts
+++ b/src/commands/manage/ExitCommand.ts
@@ -1,8 +1,8 @@
 import { Message } from 'discord.js';
 
 import * as exits from '~/util/db/Exits';
-import { getSounds } from '~/util/SoundUtil';
 import localize from '~/util/i18n/localize';
+import { getSounds } from '~/util/SoundUtil';
 
 import Command from '../base/Command';
 

--- a/src/commands/manage/ExitCommand.ts
+++ b/src/commands/manage/ExitCommand.ts
@@ -2,22 +2,27 @@ import { Message } from 'discord.js';
 
 import * as exits from '~/util/db/Exits';
 import { getSounds } from '~/util/SoundUtil';
+import localize from '~/util/i18n/localize';
 
 import Command from '../base/Command';
 
 export class ExitCommand extends Command {
   public readonly triggers = ['exit'];
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     const [exitSound] = params;
+    const { id: authorId } = await message.referencedAuthor();
     if (!exitSound) {
-      exits.remove(message.author.id);
+      exits.remove(authorId);
       return;
     }
 
     const sounds = getSounds();
-    if (!sounds.includes(exitSound)) return;
+    if (!sounds.includes(exitSound)) {
+      await message.edit(localize.t('errors.sounds.notFound', { sound: exitSound }));
+      return;
+    }
 
-    exits.add(message.author.id, exitSound);
+    exits.add(authorId, exitSound);
   }
 }

--- a/src/commands/manage/ModifyCommand.ts
+++ b/src/commands/manage/ModifyCommand.ts
@@ -24,7 +24,7 @@ export class ModifyCommand extends Command {
 
     const options = MODIFIER_OPTIONS[modifier];
     if (!options) {
-      message.channel.send(localize.t('commands.modify.notFound', { modifier }));
+      await message.edit(localize.t('commands.modify.notFound', { modifier }));
       return;
     }
 
@@ -32,7 +32,7 @@ export class ModifyCommand extends Command {
       commandParams.length < options.parameters.min ||
       commandParams.length > options.parameters.max
     ) {
-      message.channel.send(options.usage);
+      await message.edit(options.usage);
       return;
     }
 
@@ -41,9 +41,9 @@ export class ModifyCommand extends Command {
     try {
       await this.performModification(fileInfo, modifier, commandParams);
       await this.replace(fileInfo);
-      message.channel.send(localize.t('commands.modify.success', { modifier, sound }));
+      await message.edit(localize.t('commands.modify.success', { modifier, sound }));
     } catch (error) {
-      this.handleError(message, error, { modifier, sound });
+      await this.handleError(message, error, { modifier, sound });
     }
   }
 
@@ -103,12 +103,12 @@ export class ModifyCommand extends Command {
     return { currentFile, tempFile };
   }
 
-  private handleError(message: Message, error: Error, { modifier, sound }: ErrorParams) {
+  private async handleError(message: Message, error: Error, { modifier, sound }: ErrorParams) {
     if (error instanceof FormatError) {
-      message.channel.send(error.message);
+      await message.edit(error.message);
       return;
     }
 
-    message.channel.send(localize.t('commands.modify.error', { modifier, sound }));
+    await message.edit(localize.t('commands.modify.error', { modifier, sound }));
   }
 }

--- a/src/commands/manage/RemoveCommand.ts
+++ b/src/commands/manage/RemoveCommand.ts
@@ -13,15 +13,15 @@ export class RemoveCommand extends Command {
   public readonly usage = 'Usage: !remove <sound>';
   public readonly elevated = true;
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     if (params.length !== this.numberOfParameters) {
-      message.channel.send(this.usage);
+      await message.edit(this.usage);
       return;
     }
 
     const sound = params.shift()!;
     if (!existsSound(sound)) {
-      message.channel.send(localize.t('commands.remove.notFound', { sound }));
+      await message.edit(localize.t('commands.remove.notFound', { sound }));
       return;
     }
 
@@ -29,6 +29,6 @@ export class RemoveCommand extends Command {
     fs.unlinkSync(file);
     sounds.remove(sound);
 
-    message.channel.send(localize.t('commands.remove.success', { sound }));
+    await message.edit(localize.t('commands.remove.success', { sound }));
   }
 }

--- a/src/commands/manage/RenameCommand.ts
+++ b/src/commands/manage/RenameCommand.ts
@@ -13,11 +13,11 @@ export class RenameCommand extends Command {
   public readonly usage = 'Usage: !rename <old> <new>';
   public readonly elevated = true;
 
-  public run(message: Message, params: string[]) {
-    if (!message.member) return;
+  public async run(message: Message, params: string[]) {
+    if (!message.reference!.guildID) return;
 
     if (params.length !== this.numberOfParameters) {
-      message.channel.send(this.usage);
+      await message.edit(this.usage);
       return;
     }
 
@@ -25,12 +25,12 @@ export class RenameCommand extends Command {
     const sounds = getSounds();
 
     if (!sounds.includes(oldName)) {
-      message.channel.send(localize.t('commands.rename.notFound', { oldName }));
+      await message.edit(localize.t('commands.rename.notFound', { oldName }));
       return;
     }
 
     if (sounds.includes(newName)) {
-      message.channel.send(localize.t('errors.sounds.exists', { sound: newName }));
+      await message.edit(localize.t('errors.sounds.exists', { sound: newName }));
       return;
     }
 
@@ -40,6 +40,6 @@ export class RenameCommand extends Command {
     fs.renameSync(oldFile, newFile);
     soundsDb.rename(oldName, newName);
 
-    message.channel.send(localize.t('commands.rename.success', { newName, oldName }));
+    await message.edit(localize.t('commands.rename.success', { newName, oldName }));
   }
 }

--- a/src/commands/manage/SearchCommand.ts
+++ b/src/commands/manage/SearchCommand.ts
@@ -11,22 +11,22 @@ export class SearchCommand extends Command {
   public readonly numberOfParameters = 1;
   public readonly usage = 'Usage: !search <tag>';
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     if (params.length !== this.numberOfParameters) {
-      message.channel.send(this.usage);
+      await message.edit(this.usage);
       return;
     }
 
     const tag = params.shift()!;
     const results = getSounds().filter(sound => sound.includes(tag));
+    const author = await message.referencedAuthor();
     sounds.withTag(tag).forEach(sound => results.push(sound));
 
     if (!results.length) {
-      message.author.send(localize.t('commands.search.notFound'));
-      return;
+      await author.send(localize.t('commands.search.notFound'));
     }
 
     const uniqueResults = [...new Set(results)].sort();
-    message.author.send(uniqueResults.join('\n'));
+    await author.send(uniqueResults.join('\n'));
   }
 }

--- a/src/commands/manage/SoundsCommand.ts
+++ b/src/commands/manage/SoundsCommand.ts
@@ -9,15 +9,16 @@ import chunkedMessages from '../util/chunkedMessages';
 export class SoundsCommand extends ConfigCommand {
   public readonly triggers = ['sounds'];
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     const sounds = getSounds();
+    const author = await message.referencedAuthor();
 
     if (!sounds.length) {
-      message.author.send(localize.t('commands.sounds.notFound', { prefix: this.config.prefix }));
+      await author.send(localize.t('commands.sounds.notFound', { prefix: this.config.prefix }));
       return;
     }
 
     const page = parseInt(params[0]);
-    chunkedMessages(sounds, page).forEach(chunk => message.author.send(chunk));
+    chunkedMessages(sounds, page).forEach(chunk => author.send(chunk));
   }
 }

--- a/src/commands/manage/StopCommand.ts
+++ b/src/commands/manage/StopCommand.ts
@@ -5,13 +5,13 @@ import QueueCommand from '../base/QueueCommand';
 export class StopCommand extends QueueCommand {
   public readonly triggers = ['leave', 'stop'];
 
-  public run(message: Message) {
-    if (!message.guild) return;
-    if (!message.guild.voice) return;
+  public async run(message: Message) {
+    if (!message.reference!.guildID) return;
 
     this.queue.clear();
 
-    const { connection: voiceConnection } = message.guild.voice;
+    const originalMsg = await message.referencedMessage();
+    const { connection: voiceConnection } = originalMsg.guild!.voice!;
     if (voiceConnection) voiceConnection.disconnect();
   }
 }

--- a/src/commands/manage/TagCommand.ts
+++ b/src/commands/manage/TagCommand.ts
@@ -12,21 +12,22 @@ export class TagCommand extends Command {
   public readonly usage = 'Usage: !tag <sound> [<tag> ... <tagN> | clear]';
   public readonly elevated = true;
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     if (params.length < this.numberOfParameters) {
-      message.channel.send(this.usage);
+      await message.edit(this.usage);
       return;
     }
 
     const sound = params.shift()!;
     if (!getSounds().includes(sound)) {
-      message.channel.send(localize.t('commands.tag.notFound', { sound }));
+      await message.edit(localize.t('commands.tag.notFound', { sound }));
       return;
     }
 
     if (!params.length) {
       const tags = sounds.listTags(sound).join(', ');
-      message.author.send(localize.t('commands.tag.found', { sound, tags }));
+      const author = await message.referencedAuthor();
+      await author.send(localize.t('commands.tag.found', { sound, tags }));
       return;
     }
 

--- a/src/commands/manage/TagsCommand.ts
+++ b/src/commands/manage/TagsCommand.ts
@@ -9,12 +9,13 @@ import chunkedMessages from '../util/chunkedMessages';
 export class TagsCommand extends Command {
   public readonly triggers = ['tags'];
 
-  public run(message: Message, params: string[]) {
+  public async run(message: Message, params: string[]) {
     const sounds = getSounds();
     const soundsWithTags = this.formattedMessage(sounds);
+    const author = await message.referencedAuthor();
 
     const page = parseInt(params[0]);
-    chunkedMessages(soundsWithTags, page).forEach(chunk => message.author.send(chunk));
+    chunkedMessages(soundsWithTags, page).forEach(chunk => author.send(chunk));
   }
 
   private formattedMessage(sounds: string[]) {

--- a/src/commands/manage/add/downloader/AttachmentDownloader.ts
+++ b/src/commands/manage/add/downloader/AttachmentDownloader.ts
@@ -21,13 +21,14 @@ export default class AttachmentDownloader extends BaseDownloader {
     try {
       await this.addSounds(message);
     } catch (error) {
-      this.handleError(message, error);
+      await this.handleError(message, error);
     }
   }
 
   private async addSounds(message: Message) {
     // NOTE: .forEach swallows exceptions in an async setup, so use for..of
-    for (const attachment of message.attachments.array()) {
+    const originalMsg = await message.referencedMessage();
+    for (const attachment of originalMsg.attachments.array()) {
       this.validator.validate(attachment);
 
       // NOTE: This could be optimized, but it is okay to do it in succession and code is cleaner
@@ -36,7 +37,8 @@ export default class AttachmentDownloader extends BaseDownloader {
 
       // NOTE: Checked for attachment name during validation
       const name = attachment.name!.split('.')[0];
-      message.channel.send(localize.t('commands.add.success', { name }));
+      // eslint-disable-next-line no-await-in-loop
+      await message.edit(localize.t('commands.add.success', { name }));
     }
   }
 

--- a/src/commands/manage/add/downloader/BaseDownloader.ts
+++ b/src/commands/manage/add/downloader/BaseDownloader.ts
@@ -12,13 +12,13 @@ export default abstract class BaseDownloader {
 
   public abstract handle(message: Message, params: string[]): void;
 
-  protected handleError(message: Message, error: Error) {
+  protected async handleError(message: Message, error: Error) {
     if (HANDLED_ERRORS.includes(error.name)) {
-      message.channel.send(error.message);
+      await message.edit(error.message);
       return;
     }
 
     console.error(error);
-    message.channel.send(localize.t('errors.unspecific'));
+    await message.edit(localize.t('errors.unspecific'));
   }
 }

--- a/src/commands/manage/add/downloader/YoutubeDownloader.ts
+++ b/src/commands/manage/add/downloader/YoutubeDownloader.ts
@@ -29,9 +29,9 @@ export default class YoutubeDownloader extends BaseDownloader {
     try {
       this.validator.validate(soundName, url);
       await this.addSound({ end, soundName, start, url });
-      message.channel.send(localize.t('commands.add.success', { name: soundName }));
+      await message.edit(localize.t('commands.add.success', { name: soundName }));
     } catch (error) {
-      this.handleError(message, error);
+      await this.handleError(message, error);
     }
   }
 

--- a/src/commands/sound/ComboCommand.ts
+++ b/src/commands/sound/ComboCommand.ts
@@ -11,17 +11,18 @@ export class ComboCommand extends QueueCommand {
   public readonly numberOfParameters = 1;
   public readonly usage = 'Usage: !combo <sound1> ... <soundN>';
 
-  public run(message: Message, params: string[]) {
-    if (!message.member) return;
+  public async run(message: Message, params: string[]) {
+    if (!message.reference!.guildID) return;
 
     if (params.length < this.numberOfParameters) {
-      message.channel.send(this.usage);
+      await message.edit(this.usage);
       return;
     }
 
-    const { channel: voiceChannel } = message.member.voice;
+    const originalMsg = await message.referencedMessage();
+    const { channel: voiceChannel } = originalMsg.member!.voice;
     if (!voiceChannel) {
-      message.reply(localize.t('helpers.voiceChannelFinder.error'));
+      await message.edit(localize.t('helpers.voiceChannelFinder.error'));
       return;
     }
 

--- a/src/commands/sound/LoopCommand.ts
+++ b/src/commands/sound/LoopCommand.ts
@@ -11,20 +11,24 @@ export class LoopCommand extends QueueCommand {
   public readonly numberOfParameters = 2;
   public readonly usage = 'Usage: !loop <sound> <count>';
 
-  public run(message: Message, params: string[]) {
-    if (!message.member) return;
+  public async run(message: Message, params: string[]) {
+    if (!message.reference!.guildID) return;
 
     if (params.length > this.numberOfParameters) {
-      message.channel.send(this.usage);
+      await message.edit(this.usage);
       return;
     }
 
     const [sound, countAsString] = params;
-    if (!existsSound(sound)) return;
+    if (!existsSound(sound)) {
+      await message.edit(localize.t('errors.sounds.notFound', { sound }));
+      return;
+    }
 
-    const { channel: voiceChannel } = message.member.voice;
+    const originalMsg = await message.referencedMessage();
+    const { channel: voiceChannel } = originalMsg.member!.voice;
     if (!voiceChannel) {
-      message.reply(localize.t('helpers.voiceChannelFinder.error'));
+      await message.edit(localize.t('helpers.voiceChannelFinder.error'));
       return;
     }
 

--- a/src/commands/sound/NextCommand.ts
+++ b/src/commands/sound/NextCommand.ts
@@ -11,20 +11,24 @@ export class NextCommand extends QueueCommand {
   public readonly numberOfParameters = 1;
   public readonly usage = '!next <sound>';
 
-  public run(message: Message, params: string[]) {
-    if (!message.member) return;
+  public async run(message: Message, params: string[]) {
+    if (!message.reference!.guildID) return;
 
     if (params.length !== this.numberOfParameters) {
-      message.channel.send(this.usage);
+      await message.edit(this.usage);
       return;
     }
 
     const [sound] = params;
-    if (!existsSound(sound)) return;
+    if (!existsSound(sound)) {
+      await message.edit(localize.t('commands.tag.notFound', { sound }));
+      return;
+    }
 
-    const { channel: voiceChannel } = message.member.voice;
+    const originalMsg = await message.referencedMessage();
+    const { channel: voiceChannel } = originalMsg.member!.voice;
     if (!voiceChannel) {
-      message.reply(localize.t('helpers.voiceChannelFinder.error'));
+      await message.edit(localize.t('helpers.voiceChannelFinder.error'));
       return;
     }
 

--- a/src/commands/sound/RandomCommand.ts
+++ b/src/commands/sound/RandomCommand.ts
@@ -11,12 +11,13 @@ export class RandomCommand extends QueueCommand {
   public readonly triggers = ['random'];
   public readonly numberOfParameters = 1;
 
-  public run(message: Message, params: string[]) {
-    if (!message.member) return;
+  public async run(message: Message, params: string[]) {
+    if (!message.reference!.guildID) return;
 
-    const { channel: voiceChannel } = message.member.voice;
+    const originalMsg = await message.referencedMessage();
+    const { channel: voiceChannel } = originalMsg.member!.voice;
     if (!voiceChannel) {
-      message.reply(localize.t('helpers.voiceChannelFinder.error'));
+      await message.edit(localize.t('helpers.voiceChannelFinder.error'));
       return;
     }
 

--- a/src/commands/sound/SkipCommand.ts
+++ b/src/commands/sound/SkipCommand.ts
@@ -3,7 +3,7 @@ import QueueCommand from '../base/QueueCommand';
 export class SkipCommand extends QueueCommand {
   public readonly triggers = ['skip'];
 
-  public run() {
+  public async run() {
     this.queue.next();
   }
 }

--- a/src/commands/sound/SoundCommand.ts
+++ b/src/commands/sound/SoundCommand.ts
@@ -9,15 +9,19 @@ import QueueCommand from '../base/QueueCommand';
 export class SoundCommand extends QueueCommand {
   public readonly triggers = [];
 
-  public run(message: Message) {
-    if (!message.member) return;
+  public async run(message: Message) {
+    if (!message.reference!.guildID) return;
 
-    const sound = message.content;
-    if (!existsSound(sound)) return;
+    const originalMsg = await message.referencedMessage();
+    const sound = originalMsg.content;
+    if (!existsSound(sound)) {
+      await message.edit(localize.t('errors.sounds.notFound', { sound }));
+      return;
+    }
 
-    const { channel: voiceChannel } = message.member.voice;
+    const { channel: voiceChannel } = originalMsg.member!.voice;
     if (!voiceChannel) {
-      message.reply(localize.t('helpers.voiceChannelFinder.error'));
+      await message.edit(localize.t('helpers.voiceChannelFinder.error'));
       return;
     }
 

--- a/src/commands/sound/__mocks__/SoundCommand.ts
+++ b/src/commands/sound/__mocks__/SoundCommand.ts
@@ -3,7 +3,7 @@ import Command from '../../base/Command';
 export class SoundCommand extends Command {
   public readonly triggers = [];
 
-  public run() {
+  public async run() {
     // noop
   }
 }

--- a/src/discord/Message.ts
+++ b/src/discord/Message.ts
@@ -6,6 +6,8 @@ declare module 'discord.js' {
   interface Message {
     hasPrefix(prefix: string): boolean;
     isDirectMessage(): boolean;
+    referencedMessage(): Promise<Message>;
+    referencedAuthor(): Promise<User>;
   }
 }
 
@@ -15,4 +17,13 @@ Message.prototype.hasPrefix = function hasPrefix(prefix) {
 
 Message.prototype.isDirectMessage = function isDirectMessage() {
   return this.channel.type === 'dm';
+};
+
+Message.prototype.referencedMessage = function referencedMessage() {
+  return this.channel.messages.fetch(this.reference!.messageID!);
+};
+
+Message.prototype.referencedAuthor = async function referencedAuthor() {
+  const rMsg = await this.referencedMessage();
+  return rMsg.author;
 };

--- a/src/queue/SoundQueue.ts
+++ b/src/queue/SoundQueue.ts
@@ -126,7 +126,7 @@ export default class SoundQueue {
 
   private async handleError(error: { code: string }) {
     if (error.code === 'VOICE_JOIN_CHANNEL' && this.currentSound?.message) {
-      await this.currentSound.message.channel.send(localize.t('errors.permissions'));
+      await this.currentSound.message.edit(localize.t('errors.permissions'));
       process.exit();
     }
 


### PR DESCRIPTION
This started off as a very simple error handling commit and ended up being a big code refactor.  

The main idea is to have one single message per action that the bot will edit in order to inform user of progress/errors/status. This brings a few advantages imho: 
- we can have a real progress experience, especially for long running jobs like downloading from Youtube, 
- without polluting the chat 
- and brings a way to interact with a single user request.

Code wise, it all starts in `MessageHandler.execute` the main difference here is that I changed the message that is passed to commands. We have a new message, created by the bot, that will be **edited** to report progress. So I added a couple of methods in `Message` in order to get back the original `referencedMessage` and the `referencedAuthor`.

Slapping a big try catch there helps having an error message to users in case shit hits the fan. We also have an easy way to inform users that we are working on a request, and if the command doesn't return a message by default we can add a default `completed {command}` message.

The other big difference is in `Command.run` which is now returning a `Promise` instead of being void. This feels better to me so that the caller get back in control on when the process ends (and possibly with what kind of result, which will be useful later when making APIs).

All the other changes in all the commands simply derive from this few changes.
